### PR TITLE
change obs_shp from numpy float to int

### DIFF
--- a/src/env.py
+++ b/src/env.py
@@ -183,7 +183,7 @@ class TimeStepToGymWrapper(object):
 				except:
 					shp = 1
 				obs_shp.append(shp)
-			obs_shp = (np.sum(obs_shp),)
+			obs_shp = (np.sum(obs_shp, dtype=np.int32),)
 			assert modality != 'pixels'
 		act_shp = env.action_spec().shape
 		obs_dtype = np.float32 if modality != 'pixels' else np.uint8


### PR DESCRIPTION
Observation shape variable obs_shp is np.float64 tuple which instead should have been np.int32 tuple.